### PR TITLE
chore: update printWidth to be in line with aave contracts

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
     {
       "files": "*.sol",
       "options": {
-        "printWidth": 80,
+        "printWidth": 100,
         "tabWidth": 2,
         "useTabs": false,
         "singleQuote": true,


### PR DESCRIPTION
80 char is an old standard from where screens were small. bumping to 100 will make diffing with aave contracts less painful