### PR TITLE
misc: Match Solidity Style Guide

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,10 +3,10 @@
     {
       "files": "*.sol",
       "options": {
-        "printWidth": 100,
-        "tabWidth": 2,
+        "printWidth": 120,
+        "tabWidth": 4,
         "useTabs": false,
-        "singleQuote": true,
+        "singleQuote": false,
         "bracketSpacing": false
       }
     },


### PR DESCRIPTION
This PR changes tab width to 4 spaces, print width to 120 characters, and prefers double quotes. This more closely resembles the [style guide.](https://docs.soliditylang.org/en/latest/style-guide.html)