### PR TITLE
Add prettier on git-diff command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,5 @@ test   :; forge test -vvv
 download :; cast etherscan-source --chain ${chain} -d src/etherscan/${chain}_${address} ${address}
 git-diff :
 	@mkdir -p diffs
+	@npx prettier ${before} ${after} --write
 	@printf '%s\n%s\n%s\n' "\`\`\`diff" "$$(git diff --no-index --diff-algorithm=patience --ignore-space-at-eol ${before} ${after})" "\`\`\`" > diffs/${out}.md


### PR DESCRIPTION
Quite frequently, we face the situation that deployed code does not match with the local because of different spaces or line lengths.

But it's not important, because it's not affecting logic